### PR TITLE
fix overheating of the sink

### DIFF
--- a/src/journal-gateway-zmtp-sink.c
+++ b/src/journal-gateway-zmtp-sink.c
@@ -41,6 +41,7 @@ static zctx_t *ctx;
 static void *client, *router_control;
 static bool active = true;
 uint64_t initial_time;
+long poll_wait_time = POLL_WAIT_TIME;
 
 /* cli arguments */
 int     reverse=0, at_most=-1, follow=0, listening=1;
@@ -960,6 +961,10 @@ int main ( int argc, char *argv[] ){
     int major, minor, patch;
     zmq_version(&major, &minor, &patch);
 
+    if(major<3){
+        poll_wait_time *= ZMQ_VERSION_FACTOR;
+    }
+
     printf("Uses ZMQ version %d.%d.%d\n", major, minor, patch);
 
     /* ensure existence of a machine id */
@@ -1006,7 +1011,7 @@ int main ( int argc, char *argv[] ){
     s_catch_signals();
     /* receive controls or logs, initiate connections to new sources */
     while ( active ){
-        rc=zmq_poll (items, 2, 100);
+        rc=zmq_poll (items, 2, poll_wait_time);
         /* receive logs */
         if(items[0].revents & ZMQ_POLLIN){
             response = zmsg_recv(client);

--- a/src/journal-gateway-zmtp-sink.h
+++ b/src/journal-gateway-zmtp-sink.h
@@ -8,3 +8,8 @@
 #define ENV_CTRL_EXPOSED_SOCKET "GATEWAY_CONTROL_PEER"
 
 #define UNUSED(x) (void)(x)
+
+#define POLL_WAIT_TIME 100
+
+// zmq_poll timeout changed in v3 from micro- to milli-seconds
+#define ZMQ_VERSION_FACTOR 1000


### PR DESCRIPTION
after starting the sink, the load on the processor reached nearly 100%.
the reason for this was a change in the model ZMQ handles time-out lengths:
Since v3 the base unit is milliseconds but earlier versions expect microseconds.