### PR TITLE
extend error handling

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@ journal-gateway-zmtp
 
 A gateway for transmitting of systemds journal via a zmtp connection.
 
-Version 1.0.0 - 07 Jul 2015
+Version 1.0.1 - 07 Jul 2015
 ---------------------------
 
 * Fixed overloading issue of the sink with ZMQ Versions < 3.0.0

--- a/README.md
+++ b/README.md
@@ -95,7 +95,6 @@ Installing the gateway will also install a service file to execute the gateway a
 systemctl start journal-gateway-zmtp-source    # connects by default to "tcp://127.0.0.1:5555"
 ```
 
-If you need other sockets you can write a configuration file for the service:
 The service looks for a configuration file named "zmq_gateway_source.conf" in the directory "~/conf". You can change the socket there (this only has an effect, if you execute the gateway as a systemd unit).
 
 If you want to start the gateway without using systemd, you can type

--- a/src/journal-gateway-zmtp-sink.c
+++ b/src/journal-gateway-zmtp-sink.c
@@ -44,7 +44,7 @@ uint64_t initial_time;
 long poll_wait_time = POLL_WAIT_TIME;
 
 /* cli arguments */
-int     reverse=0, at_most=-1, follow=0, listening=1;
+int     reverse=0, follow=0, listening=1;
 char    *since_timestamp=NULL, *until_timestamp=NULL, *client_socket_address=NULL, *control_socket_address=NULL,
         *format=NULL, *since_cursor=NULL, *until_cursor=NULL, *filter, *new_filter,
         *remote_journal_directory=NULL;
@@ -313,7 +313,6 @@ char* make_json_timestamp(char *timestamp){
 char *build_query_string(){
     json_t *query = json_object();
     if (reverse == 1) json_object_set_new(query, "reverse", json_true());
-    if (at_most >= 0) json_object_set_new(query, "at_most", json_integer(at_most));
     if (follow == 1) json_object_set_new(query, "follow", json_true());
     if (listening == 1) json_object_set_new(query, "listen", json_true());
     if (format != NULL) json_object_set_new(query, "format", json_string(format));
@@ -881,7 +880,6 @@ int main ( int argc, char *argv[] ){
 
     struct option longopts[] = {
         { "reverse",        no_argument,            &reverse,     1   },
-        { "at_most",        required_argument,      NULL,         'a' },
         { "since",          required_argument,      NULL,         'b' },
         { "until",          required_argument,      NULL,         'c' },
         { "since_cursor",   required_argument,      NULL,         'd' },
@@ -895,9 +893,6 @@ int main ( int argc, char *argv[] ){
     int c;
     while((c = getopt_long(argc, argv, "a:b:c:d:e:f:ghs:", longopts, NULL)) != -1) {
         switch (c) {
-            case 'a':
-                at_most = atoi(optarg);
-                break;
             case 'b':
                 since_timestamp = optarg;
                 break;
@@ -914,14 +909,13 @@ int main ( int argc, char *argv[] ){
                 fprintf(stdout,
 "journal-gateway-zmtp-sink -- receiving logs from journal-gateway-zmtp-source over the network\n\n"
 "Usage: journal-gateway-zmtp-sink   [--help] [--since] [--until]\n"
-"                                   [--since_cursor] [--until_cursor] [--at_most]\n"
+"                                   [--since_cursor] [--until_cursor]\n"
 "                                   [--follow] [--reverse] [--filter]\n\n"
 "   --help      will show this\n"
 "   --since \trequires a timestamp with a format like \"2014-10-01 18:00:00\"\n"
 "   --until \tsee --since\n"
 "   --since_cursor \trequires a log cursor, see e.g. 'journalctl -o export'\n"
 "   --until_cursor \tsee --since_cursor\n"
-"   --at_most \trequires a positive integer N, at most N logs will be sent\n"
 "\n"
 "The sink is used to wait for incomming messages from journal-gateway-zmtp-source via an exposed socket.\n"
 "Set this socket via the GATEWAY_LOG_PEER environment variable (must be usable by ZeroMQ).\n"

--- a/src/journal-gateway-zmtp-sink.c
+++ b/src/journal-gateway-zmtp-sink.c
@@ -64,13 +64,13 @@ typedef struct {
     char            *src_machine_id;
     FILE            *sjr;
     UT_hash_handle  hh; /*requirement for uthash*/
-}Logging_sources;
+}Logging_source_t;
 
 // hash to note every incomming connection
 Connection *connections = NULL;
 
 // hash to note every outgoing log (differentiated by machine-id of the logging machine)
-Logging_sources *logging_sources = NULL;
+Logging_source_t *logging_sources = NULL;
 
 typedef struct {
     char *cursor_start;
@@ -425,13 +425,13 @@ int response_handler(zframe_t* cid, zmsg_t *response){
         // received a log message
         else if(((char*)frame_data)[0] == '_'){
 
-            Logging_sources *logging_source = NULL;
+            Logging_source_t *logging_source = NULL;
             Journalentry_fieldpins pins;
             pinpoint_all_metafields(frame_data, &pins);
             char *log_machine_id = strndup(pins.machine_id_value, (pins.machine_id_end - pins.machine_id_value));
             HASH_FIND_STR(logging_sources, log_machine_id, logging_source);
             if ( logging_source == NULL){   // new machine id
-                logging_source = (Logging_sources *) malloc( sizeof(Logging_sources));
+                logging_source = (Logging_source_t *) malloc( sizeof(Logging_source_t));
                 assert(logging_source);
                 logging_source->sjr = create_log_filestream(log_machine_id);
                 logging_source->src_machine_id = log_machine_id;
@@ -749,7 +749,7 @@ int set_log_directory(char *new_directory){
     free(remote_journal_directory);
     remote_journal_directory = new_directory;
     // adjust filestreams
-    Logging_sources *i, *tmp;
+    Logging_source_t *i, *tmp;
     HASH_ITER(hh, logging_sources, i, tmp){
         pclose(i->sjr);
         i->sjr = create_log_filestream(i->src_machine_id);

--- a/src/journal-gateway-zmtp-sink.c
+++ b/src/journal-gateway-zmtp-sink.c
@@ -252,9 +252,9 @@ int pinpoint_metafields(const char* start, char** equalsign, char** end){
 }
 
 int pinpoint_all_metafields(const char *j_entry, Journalentry_fieldpins *pins){
-    const char *cursor = "__CURSOR";
-    const char *realtime = "__REALTIME_TIMESTAMP";
-    const char *monotonic = "__MONOTONIC_TIMESTAMP";
+    const char cursor[] = "__CURSOR";
+    const char realtime[] = "__REALTIME_TIMESTAMP";
+    const char monotonic[] = "__MONOTONIC_TIMESTAMP";
     //    start    equalsign   end
     char *s=NULL, *eq = NULL, *e = NULL;
 
@@ -453,9 +453,9 @@ int response_handler(zframe_t* cid, zmsg_t *response){
             write(fd, pins.monotonic_end+1, frame_size-(pins.monotonic_end - pins.cursor_start + 1));
 
             // original timestamps with prefixes
-            write(fd, orig_prefix, sizeof(orig_prefix));
+            write(fd, orig_prefix, sizeof(orig_prefix) -1);
             write(fd, pins.realtime_start, (pins.realtime_end - pins.realtime_start + 1));
-            write(fd, orig_prefix, sizeof(orig_prefix));
+            write(fd, orig_prefix, sizeof(orig_prefix) -1);
             write(fd, pins.monotonic_start, (pins.monotonic_end - pins.monotonic_start + 1));
 
             write(fd, "\n", 1);

--- a/src/journal-gateway-zmtp-sink.c
+++ b/src/journal-gateway-zmtp-sink.c
@@ -422,8 +422,8 @@ int response_handler(zframe_t* cid, zmsg_t *response){
             con_hash_delete( &connections, lookup );
             ret=2;
         }
-        else{
-			assert(((char*)frame_data)[0] == '_');
+        // received a log message
+        else if(((char*)frame_data)[0] == '_'){
 
             Logging_sources *logging_source = NULL;
             Journalentry_fieldpins pins;
@@ -471,6 +471,11 @@ int response_handler(zframe_t* cid, zmsg_t *response){
             write(fd, pins.monotonic_start, (pins.monotonic_end - pins.monotonic_start + 1));
 
             write(fd, "\n", 1);
+        }
+        else{
+            char *buf = strndup(frame_data, frame_size);
+            sd_journal_print(LOG_NOTICE, "received unexpected frame: %s", buf);
+            free(buf);
         }
         zframe_destroy (&frame);
     }while(more);

--- a/src/journal-gateway-zmtp-sink.c
+++ b/src/journal-gateway-zmtp-sink.c
@@ -1039,14 +1039,13 @@ int main ( int argc, char *argv[] ){
         { "until",          required_argument,      NULL,         'c' },
         { "since_cursor",   required_argument,      NULL,         'd' },
         { "until_cursor",   required_argument,      NULL,         'e' },
-        { "follow",         no_argument,            NULL,         'g' },
         { "help",           no_argument,            NULL,         'h' },
-        { "filter",         required_argument,      NULL,         'i' },
+        { "version",        no_argument,            NULL,         'v' },
         { 0, 0, 0, 0 }
     };
 
     int c;
-    while((c = getopt_long(argc, argv, "a:b:c:d:e:f:ghs:", longopts, NULL)) != -1) {
+    while((c = getopt_long(argc, argv, "b:c:d:e:hv", longopts, NULL)) != -1) {
         switch (c) {
             case 'b':
                 since_timestamp = optarg;
@@ -1065,7 +1064,9 @@ int main ( int argc, char *argv[] ){
 "journal-gateway-zmtp-sink -- receiving logs from journal-gateway-zmtp-source over the network\n\n"
 "Usage: journal-gateway-zmtp-sink   [--help] [--since] [--until]\n"
 "                                   [--since_cursor] [--until_cursor]\n"
-"                                   [--follow] [--reverse] [--filter]\n\n"
+"                                   [--follow] [--reverse] [--filter]\n"
+"                                   [--version]\n"
+"\n"
 "   --help      will show this\n"
 "   --since \trequires a timestamp with a format like \"2014-10-01 18:00:00\"\n"
 "   --until \tsee --since\n"
@@ -1079,6 +1080,9 @@ int main ( int argc, char *argv[] ){
 "For further controls use the journal-gateway-zmtp-control tool\n"
 "\n"
                 );
+                return 0;
+            case 'v':
+                fprintf(stdout, "Journal-Gateway-ZMTP Version %d.%d.%d\n", VMAYOR, VMINOR, VPATCH);
                 return 0;
             case 0:     /* getopt_long() set a variable, just keep going */
                 break;

--- a/src/journal-gateway-zmtp-sink.c
+++ b/src/journal-gateway-zmtp-sink.c
@@ -1219,7 +1219,7 @@ int main ( int argc, char *argv[] ){
     zsocket_destroy (ctx, router_control);
     zctx_destroy (&ctx);
 
-    sd_journal_print(LOG_INFO, "...gateway stopped");
+    sd_journal_print(LOG_INFO, "...gateway sink stopped");
     return 0;
 }
 #endif

--- a/src/journal-gateway-zmtp-sink.c
+++ b/src/journal-gateway-zmtp-sink.c
@@ -361,7 +361,7 @@ static void s_catch_signals (){
     sigaction(SIGTERM, &action, NULL);
 }
 
-/* Do sth with the received (log)message */
+/* Do something with the received (log)message */
 int response_handler(zframe_t* cid, zmsg_t *response){
     zframe_t *frame;
     void *frame_data;
@@ -527,7 +527,7 @@ int control_handler (zmsg_t *command_msg, zframe_t *cid){
 
 /* control API functions */
 
-// returns a string with the help dialogue
+// returns a string with the help dialog
 void show_help(char *ret){
     const char *msg =
         "You are talking with %s \n"
@@ -535,18 +535,18 @@ void show_help(char *ret){
         "\n"
         "       help                    will show this\n"
         "\n"
-        "   Changing the logfilters:\n"
+        "   Changing the log filters:\n"
         "   You need to set the desired filters and commit them afterwards\n"
         "       filter_add [FIELD]      requires input of the form VARIABLE=value\n"
         "                               successively added filters are ORed together\n"
         "       filter_add_conjunction  adds an AND to the list of filters, allowing to AND together the filters\n"
         "       filter_flush            drops all currently set filters\n"
         "       filter_show             shows the currently set filters\n"
-        "       filter_commit           applies the currently set filters (all sources will only send coresponding messages)\n"
+        "       filter_commit           applies the currently set filters (all sources will only send corresponding messages)\n"
         "                               WARNING: this will set the same filter on EVERY source\n"
         "\n"
         "       set_exposed_port [PORT] requires a valid tcp port (default: tcp://127.0.0.1:5555)\n"
-        "       show_exposed_port       shows the port on which the sink listens for incomming logs\n"
+        "       show_exposed_port       shows the port on which the sink listens for incoming logs\n"
         "       show_sources            shows the connected sources (characterized as ZMQ connection-IDs)\n"
         "\n"
         "       set_log_directory [DIR] sets the directory in which the received logs will be stored\n"
@@ -675,7 +675,7 @@ int filter_commit(zframe_t **response){
         zmsg_send (&m, client);
     }
     free(query_string);
-    char *stringh = "filter commited\n";
+    char *stringh = "filter committed\n";
     *response = zframe_new(stringh,strlen(stringh));
     return 1;
 }

--- a/src/journal-gateway-zmtp-sink.c
+++ b/src/journal-gateway-zmtp-sink.c
@@ -871,7 +871,7 @@ int set_log_directory(char *new_directory, zframe_t **response){
                 // directory already exists, everything's fine
                 ret = 1;
                 break;
-            default:
+            default: {}
                 // some other error occured
                 char *stringh = "error while creating the directory\n";
                 *response = zframe_new(stringh,strlen(stringh));

--- a/src/journal-gateway-zmtp-source.c
+++ b/src/journal-gateway-zmtp-source.c
@@ -1032,11 +1032,12 @@ int main (int argc, char *argv[]){
 
     struct option longopts[] = {
         { "help",       no_argument,            NULL,         'h' },
+        { "version",    no_argument,            NULL,         'v' },
         { 0, 0, 0, 0 }
     };
 
     int c;
-    while((c = getopt_long(argc, argv, "s:", longopts, NULL)) != -1) {
+    while((c = getopt_long(argc, argv, "hv", longopts, NULL)) != -1) {
         switch (c) {
             case 'h':
                 fprintf(stdout,
@@ -1046,6 +1047,9 @@ Usage: journal-gateway-zmtp-source [--help]\n\n\
 To set a socket to connect to a gateway sink set the JOURNAL_REMOTE_TARGET (must be usable by ZeroMQ)\n\
 The journal-gateway-zmtp-sink has to expose the given socket.\n\n"
                 );
+                return 0;
+            case 'v':
+                fprintf(stdout, "Journal-Gateway-ZMTP Version %d.%d.%d\n", VMAYOR, VMINOR, VPATCH);
                 return 0;
             case 0:     /* getopt_long() set a variable, just keep going */
                 break;

--- a/src/journal-gateway-zmtp-source.c
+++ b/src/journal-gateway-zmtp-source.c
@@ -254,7 +254,7 @@ int show_help(char *ret){
         "\n"
         "       shutdown                stops this application\n"
         "\n\n";
-    sprintf(ret, msg);
+    sprintf(ret, msg, program_invocation_short_name);
     return 1;
 }
 

--- a/src/journal-gateway-zmtp-source.c
+++ b/src/journal-gateway-zmtp-source.c
@@ -1205,6 +1205,6 @@ The journal-gateway-zmtp-sink has to expose the given socket.\n\n"
     send_flag(frontend, NULL, LOGOFF);
 
     zctx_destroy (&ctx);
-    sd_journal_print(LOG_INFO, "...gateway stopped");
+    sd_journal_print(LOG_INFO, "...gateway source stopped");
     return 0;
 }

--- a/src/journal-gateway-zmtp.h
+++ b/src/journal-gateway-zmtp.h
@@ -17,3 +17,7 @@
 #define SLEEP 100000L // 1500000L //  500000000L
 
 #define UNUSED(x) (void)(x)
+
+#define VMAYOR 1
+#define VMINOR 0
+#define VPATCH 1

--- a/src/journal-gateway-zmtp.h
+++ b/src/journal-gateway-zmtp.h
@@ -13,6 +13,7 @@
 #define LOGON "\007"
 #define LOGOFF "\010"
 
-#define SLEEP 0 // 1500000L //  500000000L
+// seconds:   100 micro  1.5 milli    500 milli
+#define SLEEP 100000L // 1500000L //  500000000L
 
 #define UNUSED(x) (void)(x)


### PR DESCRIPTION
fixed several unhandled errors in the sink:
* If an unexpected frame was received, the sink likely crashed. Now an appropriate log is written.
* The breaking of one of the pipes to systemd-journal-remote wasn't handled. Now an appropriate log is written and a new pipe is opened.
* Errors that resulted of the unhandled events above weren't reported. Now appropriate logs are written.

additional little changes:
* version number can be shown
* removed at_most option
* throttling in the source is now activated
* renamed data type Logging_sources to Logging_source_t to reflect that it is a type